### PR TITLE
Add CV download link to README

### DIFF
--- a/.github/workflows/update-cv-pdf.yml
+++ b/.github/workflows/update-cv-pdf.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm run build:pdf
 
       - uses: stefanzweifel/git-auto-commit-action@v5
+        if: github.ref == 'refs/heads/main'
         with:
           commit_author: GitHub Actions <actions@github.com>
           commit_message: Update CV pdf

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ This repo generates my CV into HTML and PDF.
 ## Run
 
 `npm run demo`
+
+## Latest CV
+
+My latest CV is available to download [here](https://raw.githubusercontent.com/margani/cv/main/latest/Hossein-Margani-CV.pdf).


### PR DESCRIPTION
This PR will:
* Add CV link to the readme file
* Change the update CV pdf action to only run on main branch.